### PR TITLE
Fix broken external links by correcting configuration file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,8 +5,8 @@ description: Open Performance portablE SeismiC Imaging
 logo: images/OpesciLogo-twitter-summary-card.png # 120x120 px default image used for Twitter summary card
 teaser: images/OpesciLogo-teaser.png # 400x250 px default teaser image used in image archive grid
 locale:
-baseurl: http://opesci.github.io
-production_url : http://opesci.github.io
+baseurl:
+production_url : http://opesci.org
 
 # Jekyll configuration
 


### PR DESCRIPTION
The baseurl parameter is supposed to be blank, as explained [here](http://stackoverflow.com/questions/27386169/change-site-url-to-localhost-during-jekyll-local-development). 

Changed production url as well while I was at it because it looked outdated to me too. Not sure what it changes though. 