### PR TITLE
Remove self reference

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,8 +5,8 @@ description: Open Performance portablE SeismiC Imaging
 logo: images/OpesciLogo-twitter-summary-card.png # 120x120 px default image used for Twitter summary card
 teaser: images/OpesciLogo-teaser.png # 400x250 px default teaser image used in image archive grid
 locale:
-baseurl: http://opesci.github.io
-production_url : http://opesci.github.io
+baseurl:
+production_url : http://opesci.org
 
 # Jekyll configuration
 

--- a/colaborations/index.md
+++ b/colaborations/index.md
@@ -12,7 +12,6 @@ permalink: collaborations
 Wherever possible we use other open source components as building blocks.
 Projects we are collaborating with include:
 
-* [OPESCI](https://github.com/opesci)
 * [Firedrake](http://www.firedrakeproject.org)
 * [PRAgMaTIc](https://github.com/ggorman/pragmatic)
 


### PR DESCRIPTION
To be addressed after #6 

Removed Opesci from the list of collaborations that Opesci has. 