### PR TITLE
Second attempt - fix broken external links

### DIFF
--- a/_includes/navigation-sliding.html
+++ b/_includes/navigation-sliding.html
@@ -1,8 +1,10 @@
 <nav role="navigation" class="js-menu sliding-menu-content">
 	<ul class="menu-item">
 		{% for link in site.data.navigation %}<li>
-      {% unless link.url contains 'http' %}
-        {% assign domain = site.url %}
+	{% unless link.url contains 'http' %}
+	    {% assign domain = site.url %}
+	{% else %}
+	    {% assign domain = '' %}
       {% endunless %}
 			{% if link.image %}<a href="{{ domain }}{{ link.url }}"><img src="{{ site.url }}/images/{{ link.image }}" alt="teaser" class="teaser"></a>{% endif %}
 			<a href="{{ domain }}{{ link.url }}" class="title">{{ link.title }}</a>


### PR DESCRIPTION
After a lot of trial and error, I figure that the broken external links are related to this template file. 

Adding the `else` in the statement fixes the behaviour of external links on testing locally using `jekyll serve`. However, `jekyll serve` has shown different behaviour from the github server in the past so I can't be 100% sure. 

The change does make logical sense in any case so I don't believe it poses any risk. 